### PR TITLE
Better ping limiting

### DIFF
--- a/src/main/java/kaptainwutax/monkey/command/Command.java
+++ b/src/main/java/kaptainwutax/monkey/command/Command.java
@@ -7,10 +7,14 @@ import java.util.stream.Stream;
 
 public abstract class Command {
 
-    protected String[] prefix;
+    private String[] prefix;
 
     public Command(String[] prefix) {
         this.prefix = prefix;
+    }
+
+    protected String[] getPrefix() {
+        return prefix;
     }
 
     public abstract void processCommand(MessageReceivedEvent message, String rawCommand);
@@ -20,9 +24,9 @@ public abstract class Command {
     public String getPrefixDesc() {
         StringBuilder prefix = new StringBuilder();
 
-        for(int i = 0; i < this.prefix.length; i++) {
-            prefix.append(this.prefix[i]);
-            if(i + 1 == this.prefix.length)break;
+        for(int i = 0; i < this.getPrefix().length; i++) {
+            prefix.append(this.getPrefix()[i]);
+            if(i + 1 == this.getPrefix().length)break;
             prefix.append("/");
         }
 
@@ -30,11 +34,11 @@ public abstract class Command {
     }
 
     public boolean isCommand(String command) {
-        return (Stream.of(this.prefix).anyMatch(s -> command.trim().startsWith(s)));
+        return (Stream.of(this.getPrefix()).anyMatch(s -> command.trim().startsWith(s)));
     }
 
     public String removePrefix(String command) {
-        return StrUtils.removeFirstTrim(command, Stream.of(this.prefix).filter(s -> command.trim().startsWith(s)).findFirst().get());
+        return StrUtils.removeFirstTrim(command, Stream.of(this.getPrefix()).filter(s -> command.trim().startsWith(s)).findFirst().get());
     }
 
 }

--- a/src/main/java/kaptainwutax/monkey/command/CommandMonkey.java
+++ b/src/main/java/kaptainwutax/monkey/command/CommandMonkey.java
@@ -1,12 +1,18 @@
 package kaptainwutax.monkey.command;
 
+import kaptainwutax.monkey.MonkeyBot;
 import kaptainwutax.monkey.init.Commands;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
 public class CommandMonkey extends Command {
 
-    public CommandMonkey(String[] prefix) {
-        super(prefix);
+    public CommandMonkey() {
+        super(null);
+    }
+
+    @Override
+    protected String[] getPrefix() {
+        return MonkeyBot.instance().config.commandPrefix;
     }
 
     @Override

--- a/src/main/java/kaptainwutax/monkey/holder/HolderController.java
+++ b/src/main/java/kaptainwutax/monkey/holder/HolderController.java
@@ -41,6 +41,9 @@ public class HolderController {
     private transient PingInfo rolePingInfo = new PingInfo();
     private transient PingInfo userPingInfo = new PingInfo();
 
+    // for gson
+    private HolderController() {}
+
     public HolderController(HolderGuild server) {
         this.server = server;
         this.serverId = this.server.id;

--- a/src/main/java/kaptainwutax/monkey/holder/HolderController.java
+++ b/src/main/java/kaptainwutax/monkey/holder/HolderController.java
@@ -3,9 +3,7 @@ package kaptainwutax.monkey.holder;
 import com.google.gson.annotations.Expose;
 import kaptainwutax.monkey.MonkeyBot;
 import kaptainwutax.monkey.init.Guilds;
-import kaptainwutax.monkey.utility.Log;
-import kaptainwutax.monkey.utility.MessageLimiter;
-import kaptainwutax.monkey.utility.StrUtils;
+import kaptainwutax.monkey.utility.*;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -37,6 +35,11 @@ public class HolderController {
 
     @Expose private MessageLimiter noobLimit = new MessageLimiter(-1, -1, -1,-1);
     @Expose private List<RoleMap> roleLimits = new ArrayList<RoleMap>();
+
+    private transient PingInfo everyonePingInfo = new PingInfo();
+    private transient PingInfo herePingInfo = new PingInfo();
+    private transient PingInfo rolePingInfo = new PingInfo();
+    private transient PingInfo userPingInfo = new PingInfo();
 
     public HolderController(HolderGuild server) {
         this.server = server;
@@ -135,10 +138,27 @@ public class HolderController {
         messageContent = removeHiddenText(messageContent, "```");
         messageContent = removeHiddenText(messageContent, "`");
 
-        int everyone = findSimplePing(messageContent, "@everyone");
-        int here = findSimplePing(messageContent, "@here");
-        int role = event.getMessage().getMentionedRoles().size();
-        int user = event.getMessage().getMentionedMembers().size();
+        UserPingInfo everyonePings = everyonePingInfo.get(event.getGuild().getId(), event.getAuthor().getId());
+        if (findSimplePing(messageContent, "@everyone") > 0)
+            everyonePings.addPing(event.getMessageId());
+        UserPingInfo herePings = herePingInfo.get(event.getGuild().getId(), event.getAuthor().getId());
+        if (findSimplePing(messageContent, "@here") > 0)
+            herePings.addPing(event.getMessageId());
+        UserPingInfo rolePings = rolePingInfo.get(event.getGuild().getId(), event.getAuthor().getId());
+        for (Role role : event.getMessage().getMentionedRoles())
+            rolePings.addPing(role.getId());
+        UserPingInfo userPings = userPingInfo.get(event.getGuild().getId(), event.getAuthor().getId());
+        for (Member member : event.getMessage().getMentionedMembers())
+            userPings.addPing(member.getId());
+
+        everyonePings.purge();
+        int everyone = everyonePings.getPingCount();
+        herePings.purge();
+        int here = herePings.getPingCount();
+        rolePings.purge();
+        int role = rolePings.getPingCount();
+        userPings.purge();
+        int user = userPings.getPingCount();
 
         return new int[] {everyone, here, role, user};
     }

--- a/src/main/java/kaptainwutax/monkey/holder/HolderController.java
+++ b/src/main/java/kaptainwutax/monkey/holder/HolderController.java
@@ -83,6 +83,11 @@ public class HolderController {
 
         if (!this.isConsideredSpam(event)) return;
 
+        if (MonkeyBot.instance().config.simulateBans) {
+            event.getChannel().sendMessage("If I were real monkey bot, I would have banned you O_o").queue();
+            return;
+        }
+
         this.attemptBan(event, false);
         if(!this.sendAlert)return;
 

--- a/src/main/java/kaptainwutax/monkey/init/Commands.java
+++ b/src/main/java/kaptainwutax/monkey/init/Commands.java
@@ -9,7 +9,7 @@ public class Commands {
 
     public static List<Command> COMMANDS = new ArrayList<Command>();
 
-    public static Command MONKEY = new CommandMonkey(new String[] {"monkey", "\uD83D\uDC12"});
+    public static Command MONKEY = new CommandMonkey();
     public static Command HELP = new CommandHelp(new String[] {"help"});
 
     public static Command PING = new CommandPing(new String[] {"ping", "\uD83C\uDFD3"});

--- a/src/main/java/kaptainwutax/monkey/utility/MonkeyConfig.java
+++ b/src/main/java/kaptainwutax/monkey/utility/MonkeyConfig.java
@@ -25,6 +25,10 @@ public class MonkeyConfig {
      */
     @Expose private List<UserInfo> users = new ArrayList<>();
 
+    // Debugging features
+    @Expose public String[] commandPrefix = {"monkey", "\uD83D\uDC12"};
+    @Expose public boolean simulateBans = false;
+
     public static MonkeyConfig generateConfig(String location) throws FileNotFoundException {
         return new Gson().fromJson(new FileReader(location), MonkeyConfig.class);
     }

--- a/src/main/java/kaptainwutax/monkey/utility/PingInfo.java
+++ b/src/main/java/kaptainwutax/monkey/utility/PingInfo.java
@@ -1,0 +1,38 @@
+package kaptainwutax.monkey.utility;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PingInfo {
+
+    private Map<SpamInfoKey, UserPingInfo> userSpamInfos = new HashMap<>();
+
+    public UserPingInfo get(String guildId, String userId) {
+        return userSpamInfos.computeIfAbsent(new SpamInfoKey(guildId, userId), k -> new UserPingInfo());
+    }
+
+    private static final class SpamInfoKey {
+        private final String guildId;
+        private final String userId;
+
+        public SpamInfoKey(String guildId, String userId) {
+            this.guildId = guildId;
+            this.userId = userId;
+        }
+
+        @Override
+        public int hashCode() {
+            return guildId.hashCode() + 31 * userId.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) return true;
+            if (other == null) return false;
+            if (other.getClass() != SpamInfoKey.class) return false;
+            SpamInfoKey that = (SpamInfoKey) other;
+            return guildId.equals(that.guildId) && userId.equals(that.userId);
+        }
+    }
+
+}

--- a/src/main/java/kaptainwutax/monkey/utility/UserPingInfo.java
+++ b/src/main/java/kaptainwutax/monkey/utility/UserPingInfo.java
@@ -1,0 +1,46 @@
+package kaptainwutax.monkey.utility;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class UserPingInfo {
+
+    private static final long SPAM_TIMEFRAME = 60L * 1000L * 1000L * 1000L; // one minute
+
+    private LinkedHashMap<String, Long> pingTimeStamps = new LinkedHashMap<>(1);
+
+    /**
+     * Removes ping entries which are more than a minute old
+     */
+    public void purge() {
+        long now = System.nanoTime();
+        Iterator<Map.Entry<String, Long>> itr = pingTimeStamps.entrySet().iterator();
+        while (itr.hasNext()) {
+            Map.Entry<String, Long> entry = itr.next();
+            if (now - entry.getValue() >= SPAM_TIMEFRAME)
+                itr.remove();
+            else
+                break;
+        }
+    }
+
+    /**
+     * This input string may be message IDs in the case of @everyone or @here, or role or user IDs in the case of
+     * role or user mentions.
+     */
+    public void addPing(String ping) {
+        long now = System.nanoTime();
+        // removing then re-adding puts it at the end of the LinkedHashMap
+        pingTimeStamps.remove(ping);
+        pingTimeStamps.put(ping, now);
+    }
+
+    /**
+     * WARNING: may return a higher value until calling {@link #purge()}
+     */
+    public int getPingCount() {
+        return pingTimeStamps.size();
+    }
+
+}


### PR DESCRIPTION
This PR refactors ping limiting a little. It now limits pings-per-minute rather than pings-per-message, to make it harder to bypass by splitting pings into multiple messages. This comes after a bot account tried to do just that last night.